### PR TITLE
Fix broken protocol resubscription

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-tungstenite = { workspace = true }
 tungstenite = { workspace = true, features = ["native-tls"] }
-ws-mock = { workspace = true }
 
 [workspace]
 members = ["crates/zeek-websocket-derive", "crates/zeek-websocket-types"]
@@ -57,7 +56,6 @@ tokio = "1.45.0"
 tokio-tungstenite = "0.26.2"
 trybuild = "1.0.105"
 tungstenite = "0.26.2"
-ws-mock = "0.3.1"
 zeek-websocket-derive = { path = "crates/zeek-websocket-derive" }
 zeek-websocket-types = { path = "crates/zeek-websocket-types" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,10 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 syn = { version = "2.0.103", features = ["derive", "parsing", "proc-macro", "printing"], default-features = false }
 thiserror = "2.0.12"
-tokio = "1.45.0"
-tokio-tungstenite = "0.26.2"
+tokio = "1.45.1"
+tokio-tungstenite = "0.27.0"
 trybuild = "1.0.105"
-tungstenite = "0.26.2"
+tungstenite = "0.27.0"
 zeek-websocket-derive = { path = "crates/zeek-websocket-derive" }
 zeek-websocket-types = { path = "crates/zeek-websocket-types" }
 

--- a/crates/zeek-websocket-types/src/lib.rs
+++ b/crates/zeek-websocket-types/src/lib.rs
@@ -609,6 +609,12 @@ where
     }
 }
 
+impl std::fmt::Display for Subscriptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("[{}]", self.0.join(", ")))
+    }
+}
+
 #[cfg(feature = "tungstenite")]
 impl From<Subscriptions> for tungstenite::Message {
     fn from(value: Subscriptions) -> Self {

--- a/examples/tungstenite.rs
+++ b/examples/tungstenite.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
         if let Some((topic, Event { name, args, .. })) = conn.next_event() {
             // If we received a `ping` event, respond with a `pong`.
             if name == "ping" {
-                conn.enqueue_event(topic, Event::new("pong", args));
+                conn.enqueue_event(topic, Event::new("pong", args))?;
             }
         }
     }


### PR DESCRIPTION
This previously attempted to automatically send a new subscription if a
publish on a non-subscribed topic was seen. This is not understood by
Zeek, so communicate this scenario to the caller so they can take
action, likely opening a new connection.