### PR TITLE
Add workaround for https://github.com/zeek/zeek/issues/4594

### DIFF
--- a/crates/zeek-websocket-types/src/lib.rs
+++ b/crates/zeek-websocket-types/src/lib.rs
@@ -408,6 +408,7 @@ pub enum Message {
         /// Zeek-assigned kind of the error.
         code: String,
         /// Additional context.
+        #[serde(alias = "message")] // See https://github.com/zeek/zeek/issues/4594.
         context: String,
     },
 


### PR DESCRIPTION
This seems to work for now since clients are not expected to send errors anyway so we do not need to deal with the ambiguity in how errors should be encoded.