### PR TITLE
Pass `ServiceConfig` by value

### DIFF
--- a/crates/zeek-websocket-c/src/lib.rs
+++ b/crates/zeek-websocket-c/src/lib.rs
@@ -120,7 +120,7 @@ impl Client {
 
         let mut publish = None;
 
-        let service = client::Service::new_with_config(&config, |sender| {
+        let service = client::Service::new_with_config(config, |sender| {
             publish = Some(sender);
             Inner {
                 receive_callback,

--- a/src/client.rs
+++ b/src/client.rs
@@ -130,7 +130,8 @@ pub type Outbox = mpsc::Sender<(String, Event)>;
 impl<C: ZeekClient> Service<C> {
     /// Construct a new service which the given configuration. The returned `Service` needs to be
     /// started with [`Service::serve`].
-    pub fn new_with_config<F>(config: &ServiceConfig, init: F) -> Self
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new_with_config<F>(config: ServiceConfig, init: F) -> Self
     where
         F: FnOnce(Outbox) -> C,
     {
@@ -149,7 +150,7 @@ impl<C: ZeekClient> Service<C> {
         // overwhelming the service loop with too much data. We could probably also pick a slightly
         // bigger number for less backpressure.
 
-        Self::new_with_config(&ServiceConfig::default(), init)
+        Self::new_with_config(ServiceConfig::default(), init)
     }
 
     /// Run the client against the server until either


### PR DESCRIPTION
This allows us to potentially add values which are not cheap to copy in the future.