### PR TITLE
Actually store timestamps with timezone info

### DIFF
--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -11,7 +11,7 @@ use ipnetwork::Ipv4Network;
 use time::{Date, Duration, Time};
 use tungstenite::{client::IntoClientRequest, connect};
 use zeek_websocket::{
-    Data, Event, Message, PrimitiveDateTime, Subscriptions,
+    Data, Event, Message, OffsetDateTime, Subscriptions,
     types::{IpNetwork, Port, Protocol, Value},
 };
 
@@ -39,7 +39,7 @@ fn serialize(c: &mut Criterion) {
         b.iter(|| serde_json::to_string(&Value::from(timespan)))
     });
     group.bench_function("timestamp", |b| {
-        let timestamp = PrimitiveDateTime::new(
+        let timestamp = OffsetDateTime::new_utc(
             Date::from_calendar_date(2000, time::Month::April, 1).unwrap(),
             Time::from_hms(1, 2, 3).unwrap(),
         );

--- a/bindings/node/zeek-websocket-node/src/lib.rs
+++ b/bindings/node/zeek-websocket-node/src/lib.rs
@@ -177,15 +177,9 @@ impl TryFrom<Value> for zeek_websocket::Value {
                 ))
             }
             Value::Timestamp { nanos } => {
-                let offset = UtcOffset::current_local_offset()
-                    .map_err(|e| Error::UnknownLocalTzOffset(e.to_string()))?;
                 let time = OffsetDateTime::from_unix_timestamp_nanos(nanos.into())
-                    .map_err(|e| Error::ComponentRange(e.to_string()))?
-                    .replace_offset(offset);
-                zeek_websocket::Value::Timestamp(zeek_websocket::PrimitiveDateTime::new(
-                    time.date(),
-                    time.time(),
-                ))
+                    .map_err(|e| Error::ComponentRange(e.to_string()))?;
+                zeek_websocket::Value::Timestamp(time)
             }
             Value::Vector { value } => zeek_websocket::Value::Vector(
                 value

--- a/bindings/python/tests/test_make_value.py
+++ b/bindings/python/tests/test_make_value.py
@@ -1,7 +1,7 @@
 import dataclasses
 import enum
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
 
 import pytest
@@ -117,9 +117,9 @@ def test_timespan() -> None:
 
 
 def test_timestamp() -> None:
-    x = make_value(datetime(year=2000, month=1, day=2))
+    x = make_value(datetime(year=2000, month=1, day=2, tzinfo=timezone.utc))
     assert isinstance(x, Value.Timestamp)
-    assert x.value == datetime(year=2000, month=1, day=2)
+    assert x.value == datetime(year=2000, month=1, day=2, tzinfo=timezone.utc)
 
 
 def test_vector() -> None:
@@ -198,8 +198,8 @@ def test_str() -> None:
         == "Timespan(Duration { seconds: 0, nanoseconds: 500000000 })"
     )
     assert (
-        str(Value.Timestamp(datetime(2000, 10, 2, 13, 14, 15, 16)))
-        == "Timestamp(2000-10-02 13:14:15.000016)"
+        str(Value.Timestamp(datetime(2000, 10, 2, 13, 14, 15, 16, timezone.utc)))
+        == "Timestamp(2000-10-02 13:14:15.000016 +00:00:00)"
     )
     assert str(Value.None_()) == "None_"
     assert str(Value.String("abc")) == 'String("abc")'

--- a/crates/zeek-websocket-derive/tests/unhandled-field-type-fail.stderr
+++ b/crates/zeek-websocket-derive/tests/unhandled-field-type-fail.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `Value: From<BTreeSet<u8>>` is not satisfied
             `Value` implements `From<HashSet<T>>`
             `Value` implements `From<IpAddr>`
             `Value` implements `From<IpNetwork>`
-            `Value` implements `From<PrimitiveDateTime>`
+            `Value` implements `From<OffsetDateTime>`
           and $N others
   = note: this error originates in the derive macro `ZeekType` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -58,7 +58,7 @@ enum Value {
     Integer(i64),
     Real(OrderedFloat<f64>),
     Timespan(time::Duration),
-    Timestamp(time::PrimitiveDateTime),
+    Timestamp(time::OffsetDateTime),
     Address(IpAddr),
     Subnet(IpAddr, u8),
     Port(u16, Protocol),


### PR DESCRIPTION
Zeek insists on working with timestamps in the local timezone, but in addition to being error prone this is also harder to work with. Just include the timezone in the data exposed to users.